### PR TITLE
fix: add aiohttp dependency for Socket.IO HTTP handshake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "fastmcp>=2.0.0,<3",
     "pine-assistant>=0.3.2",
+    "aiohttp>=3.8",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
python-socketio requires aiohttp for the initial HTTP handshake even with websocket transport. Without it, pine_send_message and pine_get_history fail with 'One or more namespaces failed to connect' when running via uvx (which creates an isolated environment without aiohttp pre-installed).

Fixes #1